### PR TITLE
Add contains and contains-any operators

### DIFF
--- a/src/services/evaluator.ts
+++ b/src/services/evaluator.ts
@@ -140,6 +140,11 @@ export class Evaluator {
         );
       case "contains":
         return criterion.includes(constraint.value);
+      case "contains-any":
+        return (
+          Array.isArray(constraint.value) &&
+          constraint.value.some(x => criterion.includes(x))
+        );
       default:
         return false;
     }

--- a/src/services/evaluator.ts
+++ b/src/services/evaluator.ts
@@ -138,6 +138,8 @@ export class Evaluator {
           !Array.isArray(constraint.value) ||
           !constraint.value.includes(criterion as never)
         );
+      case "contains":
+        return criterion.includes(constraint.value);
       default:
         return false;
     }

--- a/src/services/validator.ts
+++ b/src/services/validator.ts
@@ -129,7 +129,7 @@ export class Validator {
       };
     }
 
-    const operators = ["==", "!=", ">", "<", ">=", "<=", "in", "not in"];
+    const operators = ["==", "!=", ">", "<", ">=", "<=", "in", "not in", "contains"];
     if (!operators.includes(constraint.operator as Operator)) {
       return {
         isValid: false,

--- a/src/services/validator.ts
+++ b/src/services/validator.ts
@@ -129,7 +129,7 @@ export class Validator {
       };
     }
 
-    const operators = ["==", "!=", ">", "<", ">=", "<=", "in", "not in", "contains"];
+    const operators = ["==", "!=", ">", "<", ">=", "<=", "in", "not in", "contains", "contains-any"];
     if (!operators.includes(constraint.operator as Operator)) {
       return {
         isValid: false,

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -1,5 +1,5 @@
 export type ConditionType = "any" | "all" | "none";
-export type Operator = "==" | "!=" | ">" | "<" | ">=" | "<=" | "in" | "not in";
+export type Operator = "==" | "!=" | ">" | "<" | ">=" | "<=" | "in" | "not in" | "contains";
 
 export interface Constraint {
   field: string;

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -1,5 +1,5 @@
 export type ConditionType = "any" | "all" | "none";
-export type Operator = "==" | "!=" | ">" | "<" | ">=" | "<=" | "in" | "not in" | "contains";
+export type Operator = "==" | "!=" | ">" | "<" | ">=" | "<=" | "in" | "not in" | "contains" | "contains-any";
 
 export interface Constraint {
   field: string;

--- a/test/engine.spec.ts
+++ b/test/engine.spec.ts
@@ -4,6 +4,7 @@ import { valid1Json } from "./rulesets/valid1.json";
 import { valid2Json } from "./rulesets/valid2.json";
 import { valid3Json } from "./rulesets/valid3.json";
 import { valid4Json } from "./rulesets/valid4.json";
+import { valid5Json } from "./rulesets/valid5.json";
 
 import { invalid1Json } from "./rulesets/invalid1.json";
 
@@ -187,5 +188,15 @@ describe("RulePilot engine correctly", () => {
         Foo: 10,
       })
     ).toEqual(true);
+  });
+
+  it("Evaluates a simple ruleset with a contains condition", async () => {
+    expect(
+      await RulePilot.evaluate(valid5Json, { countries: ["US", "FR"] })
+    ).toEqual(true);
+
+    expect(
+      await RulePilot.evaluate(valid5Json, { countries: ["CA", "FR"] })
+    ).toEqual(false);
   });
 });

--- a/test/engine.spec.ts
+++ b/test/engine.spec.ts
@@ -190,13 +190,13 @@ describe("RulePilot engine correctly", () => {
     ).toEqual(true);
   });
 
-  it("Evaluates a simple ruleset with a contains condition", async () => {
+  it("Evaluates a simple ruleset with a contains and contains-any condition", async () => {
     expect(
-      await RulePilot.evaluate(valid5Json, { countries: ["US", "FR"] })
+      await RulePilot.evaluate(valid5Json, { countries: ["US", "FR"], word: "xylophone" })
     ).toEqual(true);
 
     expect(
-      await RulePilot.evaluate(valid5Json, { countries: ["CA", "FR"] })
+      await RulePilot.evaluate(valid5Json, { countries: ["US", "CA"], word: "trombone" })
     ).toEqual(false);
   });
 });

--- a/test/rulesets/valid5.json.ts
+++ b/test/rulesets/valid5.json.ts
@@ -6,8 +6,18 @@ export const valid5Json: Rule = {
       {
         field: "countries",
         operator: "contains",
-        value: "US",
+        value: "US"
       },
+      {
+        field: "countries",
+        operator: "contains-any",
+        value: ["FR", "GB"]
+      },
+      {
+        field: "word",
+        operator: "contains",
+        value: "phone"
+      }
     ],
   },
 };

--- a/test/rulesets/valid5.json.ts
+++ b/test/rulesets/valid5.json.ts
@@ -1,0 +1,13 @@
+import { Rule } from "../../src";
+
+export const valid5Json: Rule = {
+  conditions: {
+    all: [
+      {
+        field: "countries",
+        operator: "contains",
+        value: "US",
+      },
+    ],
+  },
+};


### PR DESCRIPTION
This adds two new operators:
- `contains`: check if an array includes a particular value or if a string contains a particular substring
- `contains-any`: check if an array contains any value from an array of values

## Usage

```ts
import { RulePilot, Rule } from "rulepilot";

const rulePilot = new RulePilot();

const rule: Rule = {
  conditions: {
    all: [
      {
        field: "data.countries",
        operator: "contains",
        value: "US"
      },
      {
        field: "data.countries",
        operator: "contains-any",
        value: ["FR", "GB"]
      },
      { 
        field: "data.word",
        operator: "contains",
        value: "phone"
      }
    ],
  },
};

// Define the criteria which will be evaluated against the rule
const criteria = {
  data: { 
    countries: ["US", "GB", "FR"],
    word: "xylophone",
  }
};
  
(async () => {
  const result = await rulePilot.evaluate(rule, criteria);
  console.log(result); // true
})();
```